### PR TITLE
http_server: fix locale detection

### DIFF
--- a/integration_tests/suite/test_aastra.py
+++ b/integration_tests/suite/test_aastra.py
@@ -249,7 +249,7 @@ class TestAastra(BasePhonedIntegrationTest):
             xivo_user_uuid=USER_1_UUID,
             profile=DEFAULT_PROFILE,
             term='no-result',
-            headers={'Accept-Language': 'fr'},
+            headers={'Accept-Language': 'gibberish,fr-CA,*q=nothing'},
         )
         assert_that(response.status_code, equal_to(200))
         assert_that(

--- a/integration_tests/suite/test_cisco.py
+++ b/integration_tests/suite/test_cisco.py
@@ -309,7 +309,7 @@ class TestCisco(BasePhonedIntegrationTest):
             xivo_user_uuid=USER_1_UUID,
             profile=DEFAULT_PROFILE,
             term='no-result',
-            headers={'Accept-Language': 'fr'},
+            headers={'Accept-Language': 'gibberish,fr-CA,*q=nothing'},
         )
         assert_that(response.status_code, equal_to(200))
         assert_that(

--- a/integration_tests/suite/test_htek.py
+++ b/integration_tests/suite/test_htek.py
@@ -208,7 +208,7 @@ class TestHtek(BasePhonedIntegrationTest):
             xivo_user_uuid=USER_1_UUID,
             profile=DEFAULT_PROFILE,
             term='no-result',
-            headers={'Accept-Language': 'fr'},
+            headers={'Accept-Language': 'gibberish,fr-CA,*q=nothing'},
         )
         assert_that(response.status_code, equal_to(200))
         assert_that(

--- a/integration_tests/suite/test_polycom.py
+++ b/integration_tests/suite/test_polycom.py
@@ -260,7 +260,7 @@ class TestPolycom(BasePhonedIntegrationTest):
             xivo_user_uuid=USER_1_UUID,
             profile=DEFAULT_PROFILE,
             term='no-result',
-            headers={'Accept-Language': 'fr'},
+            headers={'Accept-Language': 'gibberish,fr-CA,*q=nothing'},
         )
         assert_that(response.status_code, equal_to(200))
         assert_that(

--- a/integration_tests/suite/test_snom.py
+++ b/integration_tests/suite/test_snom.py
@@ -258,7 +258,7 @@ class TestSnom(BasePhonedIntegrationTest):
             xivo_user_uuid=USER_1_UUID,
             profile=DEFAULT_PROFILE,
             term='no-result',
-            headers={'Accept-Language': 'fr'},
+            headers={'Accept-Language': 'gibberish,fr-CA,*q=nothing'},
         )
         assert_that(response.status_code, equal_to(200))
         assert_that(

--- a/integration_tests/suite/test_thomson.py
+++ b/integration_tests/suite/test_thomson.py
@@ -208,7 +208,7 @@ class TestThomson(BasePhonedIntegrationTest):
             xivo_user_uuid=USER_1_UUID,
             profile=DEFAULT_PROFILE,
             term='no-result',
-            headers={'Accept-Language': 'fr'},
+            headers={'Accept-Language': 'gibberish,fr-CA,*q=nothing'},
         )
         assert_that(response.status_code, equal_to(200))
         assert_that(

--- a/integration_tests/suite/test_yealink.py
+++ b/integration_tests/suite/test_yealink.py
@@ -208,7 +208,7 @@ class TestYealink(BasePhonedIntegrationTest):
             xivo_user_uuid=USER_1_UUID,
             profile=DEFAULT_PROFILE,
             term='no-result',
-            headers={'Accept-Language': 'fr'},
+            headers={'Accept-Language': 'gibberish,fr-CA,*q=nothing'},
         )
         assert_that(response.status_code, equal_to(200))
         assert_that(


### PR DESCRIPTION
reason: the detection failed when the accept language string was not
standard, like fr-fr,*q=12312 like the Polycom sends. It also always
fell back on the first language of the set and being a set, there is no
order so most of the time it was not English.