### PR TITLE
test: use explicit ipv4 addr to connect docker

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -60,28 +60,28 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
     @classmethod
     def make_auth(cls):
         return AuthClient(
-            'localhost', cls.service_port(9497, 'auth'), prefix=None, https=False
+            '127.0.0.1', cls.service_port(9497, 'auth'), prefix=None, https=False
         )
 
     @classmethod
     def make_bus(cls):
         return BusClient.from_connection_fields(
-            host='localhost', port=cls.service_port(5672, 'rabbitmq')
+            host='127.0.0.1', port=cls.service_port(5672, 'rabbitmq')
         )
 
     @classmethod
     def make_amid(cls):
-        amid_client = AmidClient('localhost', port=cls.service_port(9491, 'amid'))
+        amid_client = AmidClient('127.0.0.1', port=cls.service_port(9491, 'amid'))
         amid_client.reset()
         return amid_client
 
     @classmethod
     def make_mock_auth(cls):
-        return MockAuthClient('localhost', cls.service_port(9497, 'auth'))
+        return MockAuthClient('127.0.0.1', cls.service_port(9497, 'auth'))
 
     @classmethod
     def make_mock_confd(cls):
-        confd_client = ConfdClient('localhost', cls.service_port(9486, 'confd'))
+        confd_client = ConfdClient('127.0.0.1', cls.service_port(9486, 'confd'))
         confd_client.reset()
         return confd_client
 
@@ -133,21 +133,21 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
 
     @classmethod
     def get_status_result(self):
-        url = u'http://localhost:{port}/0.1/status'
+        url = u'http://127.0.0.1:{port}/0.1/status'
         port = self.service_port(9498, 'phoned')
         result = requests.get(url.format(port=port))
         return result.json()
 
     @classmethod
     def get_status_result_by_https(self):
-        url = u'https://localhost:{port}/0.1/status'
+        url = u'https://127.0.0.1:{port}/0.1/status'
         port = self.service_port(9499, 'phoned')
         result = requests.get(url.format(port=port), verify=False)
         return result.json()
 
     @classmethod
     def get_menu_result(self, profile, vendor, xivo_user_uuid=None):
-        url = 'http://localhost:{port}/0.1/directories/menu/{profile}/{vendor}'
+        url = 'http://127.0.0.1:{port}/0.1/directories/menu/{profile}/{vendor}'
         params = {'xivo_user_uuid': xivo_user_uuid}
         port = self.service_port(9498, 'phoned')
         result = requests.get(
@@ -159,7 +159,7 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
     def get_ssl_menu_result(self, profile, vendor, xivo_user_uuid=None):
         params = {'xivo_user_uuid': xivo_user_uuid}
         port = self.service_port(9499, 'phoned')
-        url = 'https://localhost:{port}/0.1/directories/menu/{profile}/{vendor}'
+        url = 'https://127.0.0.1:{port}/0.1/directories/menu/{profile}/{vendor}'
         result = requests.get(
             url.format(port=port, profile=profile, vendor=vendor),
             params=params,
@@ -171,7 +171,7 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
     def get_input_result(self, profile, vendor, xivo_user_uuid=None):
         params = {'xivo_user_uuid': xivo_user_uuid}
         port = self.service_port(9498, 'phoned')
-        url = 'http://localhost:{port}/0.1/directories/input/{profile}/{vendor}'
+        url = 'http://127.0.0.1:{port}/0.1/directories/input/{profile}/{vendor}'
         result = requests.get(
             url.format(port=port, profile=profile, vendor=vendor), params=params
         )
@@ -181,7 +181,7 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
     def get_ssl_input_result(self, profile, vendor, xivo_user_uuid=None):
         params = {'xivo_user_uuid': xivo_user_uuid}
         port = self.service_port(9499, 'phoned')
-        url = 'https://localhost:{port}/0.1/directories/input/{profile}/{vendor}'
+        url = 'https://127.0.0.1:{port}/0.1/directories/input/{profile}/{vendor}'
         result = requests.get(
             url.format(port=port, profile=profile, vendor=vendor),
             params=params,
@@ -195,7 +195,7 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
     ):
         params = {'xivo_user_uuid': xivo_user_uuid, 'term': term}
         port = self.service_port(9498, 'phoned')
-        url = 'http://localhost:{port}/0.1/directories/lookup/{profile}/{vendor}'
+        url = 'http://127.0.0.1:{port}/0.1/directories/lookup/{profile}/{vendor}'
         result = requests.get(
             url.format(port=port, profile=profile, vendor=vendor),
             params=params,
@@ -209,7 +209,7 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
     ):
         params = {'xivo_user_uuid': xivo_user_uuid, 'term': term}
         port = self.service_port(9498, 'phoned')
-        url = 'http://localhost:{port}/0.1/{vendor}/directories/lookup/{profile}'
+        url = 'http://127.0.0.1:{port}/0.1/{vendor}/directories/lookup/{profile}'
         result = requests.get(
             url.format(port=port, profile=profile, vendor=vendor),
             params=params,
@@ -227,7 +227,7 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
         if kwargs:
             params.update(**kwargs)
         port = self.service_port(9498, 'phoned')
-        url = 'http://localhost:{port}/0.1/directories/lookup/{profile}/gigaset/{xivo_user_uuid}'
+        url = 'http://127.0.0.1:{port}/0.1/directories/lookup/{profile}/gigaset/{xivo_user_uuid}'
         result = requests.get(
             url.format(port=port, profile=profile, xivo_user_uuid=xivo_user_uuid),
             params=params,
@@ -238,7 +238,7 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
     @classmethod
     def get_ssl_lookup_result(self, profile, vendor, headers=None, **kwargs):
         port = self.service_port(9499, 'phoned')
-        url = 'https://localhost:{port}/0.1/directories/lookup/{profile}/{vendor}'
+        url = 'https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/{vendor}'
         result = requests.get(
             url.format(port=port, profile=profile, vendor=vendor),
             params=kwargs,
@@ -252,7 +252,7 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
         self, profile, vendor, headers=None, **kwargs
     ):
         port = self.service_port(9499, 'phoned')
-        url = 'https://localhost:{port}/0.1/{vendor}/directories/lookup/{profile}'
+        url = 'https://127.0.0.1:{port}/0.1/{vendor}/directories/lookup/{profile}'
         result = requests.get(
             url.format(port=port, profile=profile, vendor=vendor),
             params=kwargs,
@@ -271,7 +271,7 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
         if kwargs:
             params.update(**kwargs)
         port = self.service_port(9499, 'phoned')
-        url = 'https://localhost:{port}/0.1/directories/lookup/{profile}/gigaset/{xivo_user_uuid}'
+        url = 'https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/gigaset/{xivo_user_uuid}'
         result = requests.get(
             url.format(port=port, profile=profile, xivo_user_uuid=xivo_user_uuid),
             params=params,
@@ -284,7 +284,7 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
         params = {'enabled': enabled}
         port = self.service_port(9499, 'phoned')
         enable_status = 'enable' if enabled else 'disable'
-        url = 'https://localhost:{port}/0.1/{vendor}/users/{user_uuid}/services/{service_name}/{enabled}'.format(
+        url = 'https://127.0.0.1:{port}/0.1/{vendor}/users/{user_uuid}/services/{service_name}/{enabled}'.format(
             port=port,
             vendor=vendor,
             user_uuid=user_uuid,
@@ -299,7 +299,7 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
         headers = {'X-Auth-Token': token_uuid}
         port = self.service_port(9499, 'phoned')
         url = (
-            'https://localhost:{port}/0.1/endpoints/{endpoint_name}/hold/start'.format(
+            'https://127.0.0.1:{port}/0.1/endpoints/{endpoint_name}/hold/start'.format(
                 port=port,
                 endpoint_name=endpoint_name,
             )
@@ -311,7 +311,7 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
     def get_endpoint_hold_stop_result(self, endpoint_name, token_uuid):
         headers = {'X-Auth-Token': token_uuid}
         port = self.service_port(9499, 'phoned')
-        url = 'https://localhost:{port}/0.1/endpoints/{endpoint_name}/hold/stop'.format(
+        url = 'https://127.0.0.1:{port}/0.1/endpoints/{endpoint_name}/hold/stop'.format(
             port=port,
             endpoint_name=endpoint_name,
         )
@@ -322,7 +322,7 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
     def get_endpoint_answer_result(self, endpoint_name, token_uuid):
         headers = {'X-Auth-Token': token_uuid}
         port = self.service_port(9499, 'phoned')
-        url = 'https://localhost:{port}/0.1/endpoints/{endpoint_name}/answer'.format(
+        url = 'https://127.0.0.1:{port}/0.1/endpoints/{endpoint_name}/answer'.format(
             port=port,
             endpoint_name=endpoint_name,
         )

--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -10,7 +10,6 @@ from xivo_test_helpers import bus as bus_helper
 
 
 BUS_EXCHANGE_HEADERS = Exchange('wazo-headers', type='headers')
-BUS_URL = 'amqp://guest:guest@localhost:5672//'
 BUS_QUEUE_NAME = 'integration'
 
 

--- a/integration_tests/suite/test_aastra.py
+++ b/integration_tests/suite/test_aastra.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, equal_to
@@ -56,7 +56,7 @@ class TestAastra(BasePhonedIntegrationTest):
         <AastraIPPhoneInputScreen type="string" editable="yes">
          <Title>Wazo Search</Title>
          <Prompt>Name or number:</Prompt>
-         <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/aastra?xivo_user_uuid={user_uuid}</URL>
+         <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/aastra?xivo_user_uuid={user_uuid}</URL>
          <Parameter>term</Parameter>
         </AastraIPPhoneInputScreen>""".format(
                         port=self.service_port(9499, 'phoned'),
@@ -159,7 +159,7 @@ class TestAastra(BasePhonedIntegrationTest):
          </MenuItem>
         <MenuItem>
          <Prompt>Next Page</Prompt>
-         <URI>https://localhost:{port}/0.1/directories/lookup/{profile}/aastra?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1</URI>
+         <URI>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/aastra?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1</URI>
         </MenuItem>
         </AastraIPPhoneTextMenu>""".format(
                         port=self.service_port(9499, 'phoned'),
@@ -192,7 +192,7 @@ class TestAastra(BasePhonedIntegrationTest):
         <AastraIPPhoneTextMenu style="none" destroyOnExit="yes">
         <MenuItem>
          <Prompt>Previous Page</Prompt>
-         <URI>https://localhost:{port}/0.1/directories/lookup/{profile}/aastra?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=0</URI>
+         <URI>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/aastra?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=0</URI>
         </MenuItem>
         <MenuItem>
           <Prompt>Test User1 (mobile)</Prompt>
@@ -200,7 +200,7 @@ class TestAastra(BasePhonedIntegrationTest):
          </MenuItem>
         <MenuItem>
          <Prompt>Next Page</Prompt>
-         <URI>https://localhost:{port}/0.1/directories/lookup/{profile}/aastra?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=2</URI>
+         <URI>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/aastra?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=2</URI>
         </MenuItem>
         </AastraIPPhoneTextMenu>""".format(
                         port=self.service_port(9499, 'phoned'),
@@ -231,7 +231,7 @@ class TestAastra(BasePhonedIntegrationTest):
         <AastraIPPhoneTextMenu style="none" destroyOnExit="yes">
         <MenuItem>
          <Prompt>Previous Page</Prompt>
-         <URI>https://localhost:{port}/0.1/directories/lookup/{profile}/aastra?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1</URI>
+         <URI>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/aastra?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1</URI>
         </MenuItem>
         <MenuItem>
           <Prompt>Test User2</Prompt>

--- a/integration_tests/suite/test_cisco.py
+++ b/integration_tests/suite/test_cisco.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, equal_to
@@ -38,7 +38,7 @@ class TestCisco(BasePhonedIntegrationTest):
                     <CiscoIPPhoneMenu>
                      <MenuItem>
                       <Name>Wazo Directory</Name>
-                      <URL>https://localhost:{port}/0.1/directories/input/{profile}/cisco?xivo_user_uuid={user_uuid}</URL>
+                      <URL>https://127.0.0.1:{port}/0.1/directories/input/{profile}/cisco?xivo_user_uuid={user_uuid}</URL>
                      </MenuItem>
                     </CiscoIPPhoneMenu>""".format(
                         port=self.service_port(9499, 'phoned'),
@@ -75,7 +75,7 @@ class TestCisco(BasePhonedIntegrationTest):
                     <CiscoIPPhoneInput>
                      <Title>Wazo Search</Title>
                      <Prompt>Name or number</Prompt>
-                     <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/cisco?xivo_user_uuid={user_uuid}</URL>
+                     <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/cisco?xivo_user_uuid={user_uuid}</URL>
                      <InputItem>
                       <DisplayName>Name or number</DisplayName>
                       <QueryStringParam>term</QueryStringParam>
@@ -195,7 +195,7 @@ class TestCisco(BasePhonedIntegrationTest):
 
                     <SoftKeyItem>
                     <Name>NextPage</Name>
-                    <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/cisco?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1</URL>
+                    <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/cisco?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1</URL>
                     <Position>4</Position>
                     </SoftKeyItem>
                     </CiscoIPPhoneDirectory>""".format(
@@ -239,7 +239,7 @@ class TestCisco(BasePhonedIntegrationTest):
 
                     <SoftKeyItem>
                     <Name>PrevPage</Name>
-                    <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/cisco?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=0</URL>
+                    <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/cisco?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=0</URL>
                     <Position>2</Position>
                     </SoftKeyItem>
                     <SoftKeyItem>
@@ -250,7 +250,7 @@ class TestCisco(BasePhonedIntegrationTest):
 
                     <SoftKeyItem>
                     <Name>NextPage</Name>
-                    <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/cisco?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=2</URL>
+                    <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/cisco?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=2</URL>
                     <Position>4</Position>
                     </SoftKeyItem>
                     </CiscoIPPhoneDirectory>""".format(
@@ -292,7 +292,7 @@ class TestCisco(BasePhonedIntegrationTest):
 
                     <SoftKeyItem>
                     <Name>PrevPage</Name>
-                    <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/cisco?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1</URL>
+                    <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/cisco?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1</URL>
                     <Position>2</Position>
                     </SoftKeyItem>
                     <SoftKeyItem>

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -25,7 +25,7 @@ class TestDocumentation(BasePhonedIntegrationTest):
 
     def test_documentation_errors(self):
         port = self.service_port(9499, 'phoned')
-        api_url = 'https://localhost:{port}/{version}/api/api.yml'.format(
+        api_url = 'https://127.0.0.1:{port}/{version}/api/api.yml'.format(
             port=port, version=VERSION
         )
         api = requests.get(api_url, verify=False)

--- a/integration_tests/suite/test_fanvil.py
+++ b/integration_tests/suite/test_fanvil.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, equal_to
@@ -56,7 +56,7 @@ class TestFanvil(BasePhonedIntegrationTest):
                     <FanvilIPPhoneInputScreen>
                      <Title>Wazo Search</Title>
                      <Prompt>Name or number</Prompt>
-                     <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/fanvil?xivo_user_uuid={user_uuid}</URL>
+                     <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/fanvil?xivo_user_uuid={user_uuid}</URL>
                      <InputItem>
                       <DisplayName>Name or number</DisplayName>
                       <QueryStringParam>term</QueryStringParam>
@@ -176,7 +176,7 @@ class TestFanvil(BasePhonedIntegrationTest):
 
                     <SoftKeyItem>
                     <Name>NextPage</Name>
-                    <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/fanvil?xivo_user_uuid={user_uuid}&term={term}&limit=1&offset=1</URL>
+                    <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/fanvil?xivo_user_uuid={user_uuid}&term={term}&limit=1&offset=1</URL>
                     <Position>4</Position>
                     </SoftKeyItem>
                     </FanvilIPPhoneDirectory>""".format(
@@ -220,7 +220,7 @@ class TestFanvil(BasePhonedIntegrationTest):
 
                     <SoftKeyItem>
                     <Name>PrevPage</Name>
-                    <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/fanvil?xivo_user_uuid={user_uuid}&term={term}&limit=1&offset=0</URL>
+                    <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/fanvil?xivo_user_uuid={user_uuid}&term={term}&limit=1&offset=0</URL>
                     <Position>2</Position>
                     </SoftKeyItem>
                     <SoftKeyItem>
@@ -231,7 +231,7 @@ class TestFanvil(BasePhonedIntegrationTest):
 
                     <SoftKeyItem>
                     <Name>NextPage</Name>
-                    <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/fanvil?xivo_user_uuid={user_uuid}&term={term}&limit=1&offset=2</URL>
+                    <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/fanvil?xivo_user_uuid={user_uuid}&term={term}&limit=1&offset=2</URL>
                     <Position>4</Position>
                     </SoftKeyItem>
                     </FanvilIPPhoneDirectory>""".format(
@@ -273,7 +273,7 @@ class TestFanvil(BasePhonedIntegrationTest):
 
                     <SoftKeyItem>
                     <Name>PrevPage</Name>
-                    <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/fanvil?xivo_user_uuid={user_uuid}&term={term}&limit=1&offset=1</URL>
+                    <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/fanvil?xivo_user_uuid={user_uuid}&term={term}&limit=1&offset=1</URL>
                     <Position>2</Position>
                     </SoftKeyItem>
                     <SoftKeyItem>

--- a/integration_tests/suite/test_polycom.py
+++ b/integration_tests/suite/test_polycom.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, equal_to
@@ -58,7 +58,7 @@ class TestPolycom(BasePhonedIntegrationTest):
                         <title>Wazo Search</title>
                       </head>
                       <body>
-                        <form action="https://localhost:{port}/0.1/directories/lookup/{profile}/polycom" method="get" accept-charset="utf-8">
+                        <form action="https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/polycom" method="get" accept-charset="utf-8">
                           <span>
                             <label for="it-term">Name or number:</label>
                           </span>
@@ -170,7 +170,7 @@ class TestPolycom(BasePhonedIntegrationTest):
                       <body>
                         <ol>
                     <li><a href="tel://0033123456789">Test User1</a><br /></li>
-                    <li>[<a href="https://localhost:{port}/0.1/directories/lookup/{profile}/polycom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1" title="Next">Next Page</a>]<br /></li>
+                    <li>[<a href="https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/polycom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1" title="Next">Next Page</a>]<br /></li>
                     </ol>
                       </body>
                     </html>""".format(
@@ -207,9 +207,9 @@ class TestPolycom(BasePhonedIntegrationTest):
                       </head>
                       <body>
                         <ol>
-                    <li>[<a href="https://localhost:{port}/0.1/directories/lookup/{profile}/polycom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=0" title="Previous">Previous Page</a>]<br /></li>
+                    <li>[<a href="https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/polycom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=0" title="Previous">Previous Page</a>]<br /></li>
                     <li><a href="tel://5555555555">Test User1 (mobile)</a><br /></li>
-                    <li>[<a href="https://localhost:{port}/0.1/directories/lookup/{profile}/polycom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=2" title="Next">Next Page</a>]<br /></li>
+                    <li>[<a href="https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/polycom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=2" title="Next">Next Page</a>]<br /></li>
                     </ol>
                       </body>
                     </html>""".format(
@@ -244,7 +244,7 @@ class TestPolycom(BasePhonedIntegrationTest):
                       </head>
                       <body>
                         <ol>
-                    <li>[<a href="https://localhost:{port}/0.1/directories/lookup/{profile}/polycom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1" title="Previous">Previous Page</a>]<br /></li>
+                    <li>[<a href="https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/polycom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1" title="Previous">Previous Page</a>]<br /></li>
                     <li><a href="tel://1000">Test User2</a><br /></li>
                     </ol>
                       </body>

--- a/integration_tests/suite/test_snom.py
+++ b/integration_tests/suite/test_snom.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, equal_to
@@ -56,7 +56,7 @@ class TestSnom(BasePhonedIntegrationTest):
         <SnomIPPhoneInput>
          <Title>Wazo Search</Title>
          <Prompt>Name or number:</Prompt>
-         <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/snom</URL>
+         <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/snom</URL>
          <InputItem>
           <DisplayName>Name or number</DisplayName>
           <QueryStringParam>xivo_user_uuid={user_uuid}&amp;term</QueryStringParam>
@@ -164,7 +164,7 @@ class TestSnom(BasePhonedIntegrationTest):
          </DirectoryEntry>
         <SoftKeyItem>
         <Label>NextPage</Label>
-        <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/snom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1</URL>
+        <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/snom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1</URL>
         <Name>F4</Name>
         </SoftKeyItem>
         </SnomIPPhoneDirectory>""".format(
@@ -202,12 +202,12 @@ class TestSnom(BasePhonedIntegrationTest):
          </DirectoryEntry>
         <SoftKeyItem>
         <Label>PrevPage</Label>
-        <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/snom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=0</URL>
+        <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/snom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=0</URL>
         <Name>F2</Name>
         </SoftKeyItem>
         <SoftKeyItem>
         <Label>NextPage</Label>
-        <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/snom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=2</URL>
+        <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/snom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=2</URL>
         <Name>F4</Name>
         </SoftKeyItem>
         </SnomIPPhoneDirectory>""".format(
@@ -243,7 +243,7 @@ class TestSnom(BasePhonedIntegrationTest):
          </DirectoryEntry>
         <SoftKeyItem>
         <Label>PrevPage</Label>
-        <URL>https://localhost:{port}/0.1/directories/lookup/{profile}/snom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1</URL>
+        <URL>https://127.0.0.1:{port}/0.1/directories/lookup/{profile}/snom?xivo_user_uuid={user_uuid}&amp;term={term}&amp;limit=1&amp;offset=1</URL>
         <Name>F2</Name>
         </SoftKeyItem>
         </SnomIPPhoneDirectory>""".format(


### PR DESCRIPTION
reason: service_port() returns only port bound to ipv4. Some host can
resolve localhost to ipv6 address and docker doesn't necessarily bind
the same port number on ipv4 and ipv6