### PR TITLE
Wazo-2638: Migrate wazo-phoned Marshmallow from 3.0.0b14 to 3.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ itsdangerous==0.24  # from flask
 jinja2==2.10
 kombu==4.6.11
 markupsafe==1.1.0  # from flask
-marshmallow==3.0.0b14
+marshmallow==3.10.0
 netaddr==0.7.19
 pyyaml==3.13  # from xivo-lib-python
 requests==2.21.0


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-lib-python/pull/93