### PR TITLE
pin itsdangerous version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ flask-babel==0.11.2
 flask-cors==3.0.7
 flask-restful==0.3.7
 flask==1.0.2
+itsdangerous==0.24  # from flask
 jinja2==2.10
 kombu==4.6.11
 marshmallow==3.0.0b14


### PR DESCRIPTION
why: if not pinned, pip install latest version (2.1.0) which is
incompatible with flask 1.0.2 from buster