### PR TITLE
test: use mock from unittest library

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
-mock
 pyhamcrest
 pytest

--- a/wazo_phoned/bin/tests/test_daemon.py
+++ b/wazo_phoned/bin/tests/test_daemon.py
@@ -1,9 +1,10 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, equal_to
-from mock import ANY, patch, sentinel as s
 from unittest import TestCase
+from unittest.mock import ANY, patch, sentinel as s
+
+from hamcrest import assert_that, equal_to
 
 from wazo_phoned.bin import daemon
 

--- a/wazo_phoned/tests/test_config.py
+++ b/wazo_phoned/tests/test_config.py
@@ -1,12 +1,12 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
 
 from unittest import TestCase
+from unittest.mock import Mock, patch, sentinel as s
 
 from hamcrest import assert_that, has_entries, equal_to
-from mock import Mock, patch, sentinel as s
 
 from .. import config
 

--- a/wazo_phoned/tests/test_controller.py
+++ b/wazo_phoned/tests/test_controller.py
@@ -1,9 +1,9 @@
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
 
-from mock import Mock, patch, sentinel as s
+from unittest.mock import Mock, patch, sentinel as s
 from xivo import config_helper
 
 from ..controller import Controller


### PR DESCRIPTION
why: pypi version is a backport if the python3 builtin package