### PR TITLE
Pull request for WAZO-2898-pin-importlib-metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Running unit tests
 ```
 apt-get install libpq-dev python-dev libffi-dev libyaml-dev
 pip install tox
-tox --recreate -e py27
+tox --recreate -e py37
 ```
 
 

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,3 +1,4 @@
+importlib_metadata<5.0.0  # from kombu - https://github.com/celery/kombu/issues/1600
 kombu
 openapi-spec-validator
 pyhamcrest

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ flask-babel==0.11.2
 flask-cors==3.0.7
 flask-restful==0.3.7
 flask==1.0.2
+importlib_metadata==1.6.0  # from kombu
 itsdangerous==0.24  # from flask
 jinja2==2.10
 kombu==4.6.11


### PR DESCRIPTION
## README: fix wrong python version


## pin importlib_metadata package

why: kombu use this library without pinning, and the latest version
(5.0.0) of importlib_metadata break the API.
We pin the library to the same version of current (buster) debian version