### PR TITLE
[WAZO-3664] Migrate tx version to the latest

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,8 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[wazo.wazo-phoned]
-file_filter = wazo_phoned/translations/<lang>/LC_MESSAGES/messages.po
-source_file = wazo_phoned/translations/messages.pot
-source_lang = en
-type = PO
+[o:wazo:p:wazo:r:wazo-phoned]
+file_filter            = wazo_phoned/translations/<lang>/LC_MESSAGES/messages.po
+source_file            = wazo_phoned/translations/messages.pot
+source_lang            = en
+type                   = PO
+replace_edited_strings = false
+keep_translations      = false


### PR DESCRIPTION
The latest version of tx needs to change the configuration file, the tool integrate a command to do that with tx migrate.