### PR TITLE
Use marshmallow version 3.18.0 from Bookworm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ jinja2==3.0.3  # from flask
 jsonpatch==1.25
 kombu==5.0.2
 markupsafe==2.0.1 # from jinja
-marshmallow==3.10.0
+marshmallow==3.18.0
 netaddr==0.7.19
 pyyaml==5.3.1  # from xivo-lib-python
 requests==2.25.1


### PR DESCRIPTION
This change uses the Bookworm version of marshmallow to reduce the scope of changes that are going to happen when doing the upgrade