### PR TITLE
WAZO-4352: Force json when decoding requests content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+26.02
+-----
+
+* `PATCH` request bodies to endpoints accepting JSON payload are systematically parsed as JSON, with or without a proper `Content-Type` header;
+* `PATCH` requests to endpoints accepting JSON payload and which are missing a body now return a `400` status response;
+  previously those invalid requests could be treated as valid when Content-Type was missing and bodies were not parsed;
+
 24.05
 -----
 

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -307,3 +307,38 @@ class BasePhonedIntegrationTest(AssetLaunchingTestCase):
         url = f'https://127.0.0.1:{port}/0.1/endpoints/{endpoint_name}/answer'
         result = requests.put(url, headers=headers, verify=False)
         return result
+
+    def _make_http_request(
+        self, verb: str, endpoint: str, body: str | None, headers: dict = None
+    ):
+        port = self.service_port(9499, 'phoned')
+        base_url = f'https://127.0.0.1:{port}/0.1/'
+        default_headers = {
+            'X-Auth-Token': 'valid-token-multitenant',
+        }
+        req_headers = default_headers if not headers else headers
+
+        match verb.lower():
+            case 'patch':
+                call = requests.patch
+            case 'post':
+                call = requests.post
+            case 'put':
+                call = requests.put
+            case _:
+                raise ValueError('An unexpected http verb was given')
+
+        return call(
+            base_url + endpoint,
+            headers=req_headers,
+            data=body,
+            verify=False,
+        )
+
+    def assert_empty_body_returns_400(self, urls: list[tuple[str, str]]):
+        for method, url in urls:
+            response = self._make_http_request(method, url, '')
+            assert response.status_code == 400, f'Error with url: ({method}) {url}'
+
+            response = self._make_http_request(method, url, None)
+            assert response.status_code == 400, f'Error with url: ({method}) {url}'

--- a/integration_tests/suite/test_config.py
+++ b/integration_tests/suite/test_config.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -86,3 +86,22 @@ class TestConfig(BasePhonedIntegrationTest):
         }
         result = requests.get(api_url, headers=headers, verify=False)
         assert_that(result.status_code, equal_to(401))
+
+    def test_that_patch_with_empty_body_returns_400(self):
+        port = self.service_port(9499, 'phoned')
+        api_url = f'https://127.0.0.1:{port}/{VERSION}/config'
+        headers = {
+            'X-Auth-Token': 'valid-token-multitenant',
+        }
+
+        result = requests.patch(api_url, data="", headers=headers, verify=False)
+        assert result.status_code == 400, (
+            f"expected error 400 for url: {api_url}, "
+            f"but received code {result.status_code} instead"
+        )
+
+        result = requests.patch(api_url, data=None, headers=headers, verify=False)
+        assert result.status_code == 400, (
+            f"expected error 400 for url: {api_url}, "
+            f"but received code {result.status_code} instead"
+        )

--- a/integration_tests/suite/test_config.py
+++ b/integration_tests/suite/test_config.py
@@ -87,21 +87,5 @@ class TestConfig(BasePhonedIntegrationTest):
         result = requests.get(api_url, headers=headers, verify=False)
         assert_that(result.status_code, equal_to(401))
 
-    def test_that_patch_with_empty_body_returns_400(self):
-        port = self.service_port(9499, 'phoned')
-        api_url = f'https://127.0.0.1:{port}/{VERSION}/config'
-        headers = {
-            'X-Auth-Token': 'valid-token-multitenant',
-        }
-
-        result = requests.patch(api_url, data="", headers=headers, verify=False)
-        assert result.status_code == 400, (
-            f"expected error 400 for url: {api_url}, "
-            f"but received code {result.status_code} instead"
-        )
-
-        result = requests.patch(api_url, data=None, headers=headers, verify=False)
-        assert result.status_code == 400, (
-            f"expected error 400 for url: {api_url}, "
-            f"but received code {result.status_code} instead"
-        )
+    def test_that_empty_body_patch_config_returns_400(self):
+        self.assert_empty_body_returns_400([('patch', 'config')])

--- a/wazo_phoned/plugins/config/http.py
+++ b/wazo_phoned/plugins/config/http.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import request
@@ -22,7 +22,7 @@ class ConfigResource(TokenAuthResource):
     @required_master_tenant()
     @required_acl('phoned.config.update')
     def patch(self):
-        config_patch = config_patch_schema.load(request.get_json(), many=True)
+        config_patch = config_patch_schema.load(request.get_json(force=True), many=True)
         config = self._config_service.get_config()
         patched_config = JsonPatch(config_patch).apply(config)
         self._config_service.update_config(patched_config)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens PATCH request handling and adds coverage.
> 
> - Enforces JSON parsing in `ConfigResource.patch` using `request.get_json(force=True)` so body is parsed regardless of `Content-Type`
> - Returns `400` for empty/missing bodies on JSON-accepting PATCH endpoints; adds helper `assert_empty_body_returns_400` and test for `PATCH /config`
> - Updates `CHANGELOG.md`; refreshes copyright years
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7aaf285f6895cc7c2b971f4e88480f8b7790ec0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->