### PR TITLE
docker: pin rabbitmq to version 3

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - "9497"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - 5672
     volumes:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes the integration-test Docker Compose dependency from `rabbitmq` (latest) to `rabbitmq:3`, which may slightly affect test environment behavior but not production code.
> 
> **Overview**
> Pins the integration test `rabbitmq` container image from `rabbitmq` (floating latest) to `rabbitmq:3` in `integration_tests/assets/docker-compose.yml` to make the test environment more deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 628556499174871c44d39382ae8fc51497bab81b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->