### PR TITLE
ITEM-447-dynamic-thread-pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+26.08
+-----
+
+* New `rest_api.min_threads` option: threads kept ready at all times.
+  `max_threads` is now a ceiling the pool grows to under load, not a fixed
+  thread count.
+
 26.02
 -----
 

--- a/etc/wazo-phoned/config.yml
+++ b/etc/wazo-phoned/config.yml
@@ -76,12 +76,17 @@ rest_api:
     # Allow JSON preflight requests
     allow_headers: [Content-Type, X-Auth-Token, Wazo-Tenant]
 
-  # Maximum of concurrent threads processing requests
-  # This setting applies to each listening port: by default, 10 threads are used
-  # for HTTP and 10 more threads are used for HTTPS.
+  # Minimum of concurrent threads processing requests. This many threads are
+  # kept ready at all times.
+  min_threads: 10
+
+  # Maximum of concurrent threads processing requests. The number of threads
+  # scales with demand between min_threads and max_threads.
+  # These settings apply to each listening port: by default, 10 threads are
+  # kept ready for HTTP and 10 more threads for HTTPS.
   # See the performance documentation for more details
   # https://wazo-platform.org/uc-doc/system/performance/
-  max_threads: 10
+  max_threads: 100
 
 enabled_plugins:
   aastra: True

--- a/wazo_phoned/config.py
+++ b/wazo_phoned/config.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -25,7 +25,8 @@ _DEFAULT_CONFIG = {
         },
         'authorized_subnets': ['127.0.0.1/24'],
         'cors': {'enabled': True, 'allow_headers': ['Content-Type']},
-        'max_threads': 10,
+        'min_threads': 10,
+        'max_threads': 100,
     },
     'bus': {
         'username': 'guest',

--- a/wazo_phoned/http_server.py
+++ b/wazo_phoned/http_server.py
@@ -92,10 +92,11 @@ class HTTPServer:
         if https_config['enabled']:
             try:
                 bind_addr_https = (https_config['listen'], https_config['port'])
-                server_https = wsgi.WSGIServer(
+                server_https = wsgi.DynamicWSGIServer(
                     bind_addr=bind_addr_https,
                     wsgi_app=wsgi_app,
-                    numthreads=self.config['max_threads'],
+                    numthreads=self.config['min_threads'],
+                    max=self.config['max_threads'],
                 )
                 server_https.ssl_adapter = http_helpers.ssl_adapter(
                     https_config['certificate'], https_config['private_key']
@@ -115,10 +116,11 @@ class HTTPServer:
 
         if http_config['enabled']:
             bind_addr_http = (http_config['listen'], http_config['port'])
-            server_http = wsgi.WSGIServer(
+            server_http = wsgi.DynamicWSGIServer(
                 bind_addr=bind_addr_http,
                 wsgi_app=wsgi_app,
-                numthreads=self.config['max_threads'],
+                numthreads=self.config['min_threads'],
+                max=self.config['max_threads'],
             )
             ServerAdapter(cherrypy.engine, server_http).subscribe()
             logger.debug(


### PR DESCRIPTION

Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/187

Why: max_threads was a fixed thread count spawned at startup, wasting
idle threads and DB connections on quiet systems. The pool now grows
and shrinks between the new min_threads setting and max_threads, which
becomes a real ceiling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the CherryPy WSGI server scales concurrency for all REST traffic; mis-tuned min/max could affect latency or resource use under load, though request handling logic is unchanged.
> 
> **Overview**
> Replaces a **fixed** REST worker thread count with a **dynamic pool** between `rest_api.min_threads` and `rest_api.max_threads` (via `xivo`’s `DynamicWSGIServer`).
> 
> **`min_threads`** (default 10) is how many threads stay ready per HTTP/HTTPS listener; **`max_threads`** (default raised from 10 to 100) is now the upper bound under load, not the size spawned at startup. Defaults and sample `etc/wazo-phoned/config.yml` comments are updated accordingly; **26.08** changelog entry documents the new option and semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8db785df277587b68592834bdcd006b570b2e93d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->