### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/etc/wazo-phoned/config.yml
+++ b/etc/wazo-phoned/config.yml
@@ -14,8 +14,7 @@ log_filename: /var/log/wazo-phoned.log
 # wazo-auth (authentication daemon) connection settings.
 auth:
   host: localhost
-  port: 9497
-  prefix: null
+  port: 80
   https: false
   key_file: /var/lib/wazo-auth-keys/wazo-phoned-key.yml
 

--- a/integration_tests/assets/etc/wazo-phoned/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-phoned/conf.d/50-default.yml
@@ -17,6 +17,8 @@ rest_api:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
   key_file: /tmp/auth_keys/wazo-phoned-key.yml
 
 amid:

--- a/wazo_phoned/config.py
+++ b/wazo_phoned/config.py
@@ -38,8 +38,7 @@ _DEFAULT_CONFIG = {
     },
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-phoned-key.yml',
     },


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

Notes:

* Integration test assets now pin `port: 9497` and `prefix: null` explicitly:
  their stacks have no nginx, and those values used to come from the defaults
  changed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auth connectivity depends on coordinated nginx/wazo-auth deploys; mis-ordering causes internal auth 404s, though scope is limited to connection settings.
> 
> **Overview**
> **wazo-phoned** now talks to **wazo-auth** through the nginx internal listener (`localhost:80`) instead of the auth daemon port (`9497`). The shipped `etc/wazo-phoned/config.yml` and Python defaults in `wazo_phoned/config.py` are updated together so layered config stays consistent.
> 
> The explicit `prefix` default is removed from production config; `wazo-auth-client` already uses `/api/auth`. Integration test overrides in `50-default.yml` now set `port: 9497` and `prefix: null` explicitly because those stacks have no nginx and previously inherited the old defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f9438023cd6402038ab580f7a7bf9dead5bca98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->