### PR TITLE
http: fix stop-before-start shutdown race

### DIFF
--- a/etc/wazo-phoned/config.yml
+++ b/etc/wazo-phoned/config.yml
@@ -52,12 +52,12 @@ confd:
 rest_api:
 
   http:
-    enabled: True
+    enabled: true
     listen: 0.0.0.0
     port: 9498
 
   https:
-    enabled: True
+    enabled: true
     listen: 0.0.0.0
     port: 9499
 
@@ -71,7 +71,7 @@ rest_api:
   # CORS configuration. See Flask-CORS documentation for other values.
   cors:
     # Enabled by default
-    enabled: True
+    enabled: true
     # Allow JSON preflight requests
     allow_headers: [Content-Type, X-Auth-Token, Wazo-Tenant]
 
@@ -88,15 +88,15 @@ rest_api:
   max_threads: 100
 
 enabled_plugins:
-  aastra: True
-  blf: True
-  api: True
-  cisco: True
-  fanvil: True
-  gigaset: True
-  htek: True
-  polycom: True
-  snom: True
-  status: True
-  thomson: True
-  yealink: True
+  aastra: true
+  blf: true
+  api: true
+  cisco: true
+  fanvil: true
+  gigaset: true
+  htek: true
+  polycom: true
+  snom: true
+  status: true
+  thomson: true
+  yealink: true

--- a/wazo_phoned/config.py
+++ b/wazo_phoned/config.py
@@ -15,11 +15,11 @@ _DEFAULT_CONFIG = {
     'user': 'www-data',
     'log_filename': '/var/log/wazo-phoned.log',
     'rest_api': {
-        'http': {'listen': '0.0.0.0', 'port': 9498, 'enable': True},
+        'http': {'listen': '0.0.0.0', 'port': 9498, 'enabled': True},
         'https': {
             'listen': '0.0.0.0',
             'port': 9499,
-            'enable': True,
+            'enabled': True,
             'certificate': '/usr/share/wazo-certs/server.crt',
             'private_key': '/usr/share/wazo-certs/server.key',
         },

--- a/wazo_phoned/http_server.py
+++ b/wazo_phoned/http_server.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import threading
 from datetime import timedelta
 from importlib.metadata import entry_points
 from importlib.resources import files
@@ -38,6 +39,7 @@ class HTTPServer:
         app.permanent_session_lifetime = timedelta(minutes=5)
         app.config['auth'] = config['auth']
         self.load_cors()
+        self._stopped = threading.Event()
 
     def load_cors(self):
         cors_config = dict(self.config.get('cors', {}))
@@ -138,6 +140,10 @@ class HTTPServer:
 
         list_routes(app)
 
+        if self._stopped.is_set():
+            logger.warning('stop requested during startup: not starting the server')
+            return
+
         try:
             cherrypy.engine.start()
             cherrypy.engine.wait(states.EXITING)
@@ -146,6 +152,7 @@ class HTTPServer:
             cherrypy.engine.exit()
 
     def stop(self):
+        self._stopped.set()
         cherrypy.engine.exit()
 
     def join(self):

--- a/wazo_phoned/tests/test_http_server.py
+++ b/wazo_phoned/tests/test_http_server.py
@@ -1,0 +1,53 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest.mock import patch
+
+import pytest
+
+from wazo_phoned.http_server import HTTPServer
+
+
+@pytest.fixture
+def http_server():
+    config = {
+        'rest_api': {
+            'http': {'enabled': True, 'listen': '127.0.0.1', 'port': 9498},
+            'https': {'enabled': False},
+            'min_threads': 1,
+            'max_threads': 1,
+            'cors': {'enabled': False},
+        },
+        'enabled_plugins': [],
+        'auth': {},
+    }
+    return HTTPServer(config)
+
+
+@patch('wazo_phoned.http_server.cherrypy')
+def test_stop_before_run_does_not_raise_and_sets_the_tombstone(cherrypy, http_server):
+    http_server.stop()
+
+    assert http_server._stopped.is_set()
+
+
+@patch('wazo_phoned.http_server.ServerAdapter')
+@patch('wazo_phoned.http_server.wsgi')
+@patch('wazo_phoned.http_server.cherrypy')
+def test_run_after_stop_does_not_start_the_engine(
+    cherrypy, wsgi, server_adapter, http_server
+):
+    http_server.stop()
+    http_server.run()
+
+    cherrypy.engine.start.assert_not_called()
+
+
+@patch('wazo_phoned.http_server.ServerAdapter')
+@patch('wazo_phoned.http_server.wsgi')
+@patch('wazo_phoned.http_server.cherrypy')
+def test_stop_after_run_exits_the_engine(cherrypy, wsgi, server_adapter, http_server):
+    http_server.run()
+    http_server.stop()
+
+    cherrypy.engine.exit.assert_called_once_with()


### PR DESCRIPTION
Why: a SIGTERM landing during startup was lost: engine.exit() on a
not-yet-started cherrypy engine is a no-op for a later start(), so
run() then started the engine and wait(EXITING) blocked forever;
systemd escalated to SIGKILL after TimeoutStopSec. The window was
the whole startup phase preceding run().

stop() now sets a tombstone before exiting the engine, and run()
checks it right before engine.start().

Same fix as wazo-auth (ITEM-589), adapted to the cherrypy engine.

Also on this branch: 4d74e19 fixes the config.py http/https 'enable' key typo, 524cff9 uniformizes config.yml booleans to lowercase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process shutdown and HTTP server startup timing; behavior change is narrow and covered by new tests, but mis-shutdown could still affect service restarts under systemd.
> 
> **Overview**
> Fixes a **shutdown race** where SIGTERM during startup could be ignored: `cherrypy.engine.exit()` before `engine.start()` had no lasting effect, so `run()` could still start the engine and block on `wait(EXITING)` until systemd killed the process. **`stop()`** now sets a tombstone (`threading.Event`) before exiting the engine, and **`run()`** bails out right before **`engine.start()`** if stop was already requested (same pattern as wazo-auth).
> 
> Also corrects the default REST API **`enable` → `enabled`** keys in **`config.py`** so they match what **`http_server`** reads, and normalizes **`etc/wazo-phoned/config.yml`** booleans to lowercase **`true`**.
> 
> Adds unit tests covering stop-before-run, run-after-stop (engine not started), and stop-after-run (engine exit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 524cff948e499ab2134a69ac59a1e7b886c398a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->